### PR TITLE
chore: @typescript-eslint 系依存バージョンレンジを ^8.56.1 に統一

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.56.1"
+        "@typescript-eslint/utils": "^8.0.0"
       },
       "devDependencies": {
         "@types/eslint": "^9.0.0",
@@ -30,7 +30,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.56.1",
+        "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^9.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^8.56.1"
+    "@typescript-eslint/utils": "^8.0.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^8.56.1",
+    "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^9.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## チケットへのリンク
https://github.com/pppp606/eslint-plugin-ai-readable/issues/14

## やったこと
- `@typescript-eslint` 系パッケージの `devDependencies` バージョンレンジを `^8.56.1` に統一
  - `@typescript-eslint/parser`: `^8.0.0` → `^8.56.1`
  - `@typescript-eslint/rule-tester`, `typescript-eslint` は変更なし（既に `^8.56.1`）
- `dependencies` (`@typescript-eslint/utils`) と `peerDependencies` (`@typescript-eslint/parser`) は利用者互換性を考慮し `^8.0.0` を維持
- `package-lock.json` を同期更新
- typecheck / テスト (147件) / lint の全検証パス確認

## やらないこと
- メジャーバージョンアップ（v8 → v9 等）は対象外
- `dependencies` / `peerDependencies` のバージョンレンジ引き上げ（利用者互換性のため）

## 確認
- [x] 既存テストがすべてパスすること
- [x] 型エラーが発生しないこと
- [x] lint エラーが発生しないこと
- [x] peerDependencies との整合性

## その他
- セルフレビューにて `dependencies` / `peerDependencies` のバージョンレンジを狭めるリスクが指摘されたため、これらは `^8.0.0` に戻し `devDependencies` のみ統一する方針に修正
- 実際にインストールされるバージョン (8.56.1) は変更なし
